### PR TITLE
Refactor of usage interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TemLogger
-**Temlogger** is a library with a purpose to capture and send logs to ELK, StackDriver.
+**Temlogger** is a library to capture and send logs to ELK, StackDriver.
 
 ## Logging Providers
 
@@ -27,10 +27,10 @@ Use this to specify tag version:
 Using environment variables:
 
 ```bash
-export LOGGING_PROVIDER='logstash'
-export LOGGING_URL='localhost'
-export LOGGING_PORT='5000'
-export LOGGING_ENVIRONMENT='staging'
+export TEMLOGGER_PROVIDER='logstash'
+export TEMLOGGER_URL='localhost'
+export TEMLOGGER_PORT='5000'
+export TEMLOGGER_ENVIRONMENT='staging'
 ```
 
 ```python
@@ -61,10 +61,10 @@ Example passing parameters directly to temlogger:
 import sys
 import temlogger
 
-temlogger.config.set_logging_provider('logstash')
-temlogger.config.set_logging_url('localhost')
-temlogger.config.set_logging_port(5000)
-temlogger.config.set_logging_environment('staging')
+temlogger.config.set_provider('logstash')
+temlogger.config.set_url('localhost')
+temlogger.config.set_port(5000)
+temlogger.config.set_environment('staging')
 
 test_logger = temlogger.getLogger('python-logstash-logger')
 
@@ -85,7 +85,7 @@ test_logger.info('temlogger: test with extra fields', extra=extra)
 ### Example with StackDriver
 
 ```bash
-export LOGGING_PROVIDER='stackdriver'
+export TEMLOGGER_PROVIDER='stackdriver'
 # https://cloud.google.com/docs/authentication/getting-started
 export GOOGLE_APPLICATION_CREDENTIALS='<path to json>'
 ```
@@ -119,10 +119,10 @@ import temlogger
 
 host = 'localhost'
 
-temlogger.config.set_logging_provider('logstash')
-temlogger.config.set_logging_url('localhost')
-temlogger.config.set_logging_port(5000)
-temlogger.config.set_logging_environment('staging')
+temlogger.config.set_provider('logstash')
+temlogger.config.set_url('localhost')
+temlogger.config.set_port(5000)
+temlogger.config.set_environment('staging')
 
 ```
 

--- a/temlogger/formatter.py
+++ b/temlogger/formatter.py
@@ -1,4 +1,3 @@
-import logstash
 from logstash.formatter import LogstashFormatterBase
 
 

--- a/temlogger/temlogger.py
+++ b/temlogger/temlogger.py
@@ -9,49 +9,50 @@ class LoggingProvider:
 
 
 class LoggingConfig:
-    _logging_provider = ''
-    _logging_url = ''
-    _logging_port = ''
-    _logging_environment = ''
+    _provider = ''
+    _url = ''
+    _port = ''
+    _environment = ''
 
-    def set_logging_provider(self, value):
-        self._logging_provider = value
+    def set_provider(self, value):
+        self._provider = value
 
-    def get_logging_provider(self):
-        return self._logging_provider.lower() or os.getenv('LOGGING_PROVIDER', '').lower()
+    def get_provider(self):
+        return self._provider.lower() or os.getenv('TEMLOGGER_PROVIDER', '').lower()
 
-    def set_logging_url(self, value):
-        self._logging_url = value
+    def set_url(self, value):
+        self._url = value
 
-    def get_logging_url(self):
-        return self._logging_url or os.getenv('LOGGING_URL', '')
+    def get_url(self):
+        return self._url or os.getenv('TEMLOGGER_URL', '')
 
-    def set_logging_port(self, value):
-        self._logging_port = value
+    def set_port(self, value):
+        self._port = value
 
-    def get_logging_port(self):
-        return self._logging_port or os.getenv('LOGGING_PORT', '')
+    def get_port(self):
+        return self._port or os.getenv('TEMLOGGER_PORT', '')
 
-    def set_logging_environment(self, value):
-        self._logging_environment = value
+    def set_environment(self, value):
+        self._environment = value
 
-    def get_logging_environment(self):
-        return self._logging_environment or os.getenv('LOGGING_ENVIRONMENT', '')
+    def get_environment(self):
+        return self._environment or os.getenv('TEMLOGGER_ENVIRONMENT', '')
 
     def clear(self):
-        self._logging_provider = ''
-        self._logging_url = ''
-        self._logging_port = ''
-        self._logging_environment = ''
+        self._provider = ''
+        self._url = ''
+        self._port = ''
+        self._environment = ''
 
 
 class LoggerManager:
 
     def get_logger(self, name):
-        logging_provider = config.get_logging_provider()
+        logging_provider = config.get_provider()
 
         logger = logging.getLogger(name)
-        if hasattr(logger, 'logging_provider') and logger.logging_provider == logging_provider:
+        has_log_provider = hasattr(logger, 'logging_provider')
+        if has_log_provider and logger.logging_provider == logging_provider:
             return logger
 
         logger.handlers.clear()
@@ -73,16 +74,18 @@ class LoggerManager:
         import logstash
         from .formatter import LogstashFormatter
 
-        loggin_url = config.get_logging_url()
-        logging_port = config.get_logging_port()
-        logging_environment = config.get_logging_environment()
+        logging_url = config.get_url()
+        logging_port = config.get_port()
+        logging_environment = config.get_environment()
 
         logger = logging.getLogger(name)
         logger.logging_provider = LoggingProvider.LOGSTASH
 
         logger.setLevel(logging.INFO)
-        handler = logstash.TCPLogstashHandler(loggin_url, logging_port, version=1)
-        handler.setFormatter(LogstashFormatter(environment=logging_environment))
+        handler = logstash.TCPLogstashHandler(
+            logging_url, logging_port, version=1)
+        handler.setFormatter(LogstashFormatter(
+            environment=logging_environment))
         logger.addHandler(handler)
 
         return logger
@@ -94,7 +97,7 @@ class LoggerManager:
         import google.cloud.logging
         from .formatter import StackDriverFormatter
 
-        logging_environment = config.get_logging_environment()
+        logging_environment = config.get_environment()
 
         logger = logging.getLogger(name)
         logger.logging_provider = LoggingProvider.STACK_DRIVER
@@ -103,7 +106,8 @@ class LoggerManager:
 
         handler = client.get_default_handler()
         # Setup logger explicitly with this handler
-        handler.setFormatter(StackDriverFormatter(environment=logging_environment))
+        handler.setFormatter(StackDriverFormatter(
+            environment=logging_environment))
         logger.setLevel(logging.INFO)
         logger.addHandler(handler)
 

--- a/temlogger/tests.py
+++ b/temlogger/tests.py
@@ -7,9 +7,10 @@ from unittest import mock
 
 def clean_temlogger_config():
     environments_to_clean = [
-        'LOGGING_PROVIDER',
-        'LOGGING_URL',
-        'LOGGING_PORT'
+        'TEMLOGGER_PROVIDER',
+        'TEMLOGGER_URL',
+        'TEMLOGGER_PORT'
+        'TEMLOGGER_ENVIRONMENT'
     ]
     for env in environments_to_clean:
         if env in os.environ:
@@ -46,37 +47,38 @@ class TestLogstashLogger(unittest.TestCase):
         self.assertTrue(isinstance(logger, logging.Logger))
         self.assertEqual(logger.logging_provider, 'default')
 
-        temlogger.config.set_logging_provider('logstash')
+        temlogger.config.set_provider('logstash')
         logger = temlogger.getLogger('switch-logger-1')
         self.assertTrue(isinstance(logger, logging.Logger))
         self.assertEqual(logger.logging_provider, 'logstash')
 
-        temlogger.config.set_logging_provider('default')
+        temlogger.config.set_provider('default')
         logger = temlogger.getLogger('switch-logger-1')
         self.assertTrue(isinstance(logger, logging.Logger))
         self.assertEqual(logger.logging_provider, 'default')
 
     def test_get_logstash_logger_passing_envs_by_environ(self):
-        os.environ['LOGGING_PROVIDER'] = 'logstash'
-        os.environ['LOGGING_URL'] = 'localhost'
-        os.environ['LOGGING_PORT'] = '5000'
+        os.environ['TEMLOGGER_PROVIDER'] = 'logstash'
+        os.environ['TEMLOGGER_URL'] = 'localhost'
+        os.environ['TEMLOGGER_PORT'] = '5000'
 
         logger = temlogger.getLogger('logstash-2')
         self.assertEqual(logger.logging_provider, 'logstash')
 
     def test_get_logstash_logger_passing_envs_as_parameter(self):
-        temlogger.config.set_logging_provider('logstash')
-        temlogger.config.set_logging_url('localhost')
-        temlogger.config.set_logging_port('5000')
+        temlogger.config.set_provider('logstash')
+        temlogger.config.set_url('localhost')
+        temlogger.config.set_port('5000')
+        temlogger.config.set_environment('staging')
 
         logger = temlogger.getLogger('logstash-3')
         self.assertEqual(logger.logging_provider, 'logstash')
 
     def test_get_logstash_logger_and_log_info(self):
         """"""
-        temlogger.config.set_logging_provider('logstash')
-        temlogger.config.set_logging_url('localhost')
-        temlogger.config.set_logging_port('5000')
+        temlogger.config.set_provider('logstash')
+        temlogger.config.set_url('localhost')
+        temlogger.config.set_port('5000')
 
         logger = temlogger.getLogger('logstash-3')
 
@@ -103,7 +105,7 @@ class TestStackDriverLogger(unittest.TestCase):
 
     @mock.patch("google.cloud.logging.Client")
     def test_get_stackdriver_logger_passing_envs_by_environ(self, mocked_cls):
-        os.environ['LOGGING_PROVIDER'] = 'stackdriver'
+        os.environ['TEMLOGGER_PROVIDER'] = 'stackdriver'
 
         logger = temlogger.getLogger('stackdriver-1')
 
@@ -113,7 +115,7 @@ class TestStackDriverLogger(unittest.TestCase):
     @mock.patch("google.cloud.logging.Client")
     def test_get_stackdriver_logger_passing_envs_as_parameter(self, mocked_cls):
         """"""
-        temlogger.config.set_logging_provider('stackdriver')
+        temlogger.config.set_provider('stackdriver')
 
         logger = temlogger.getLogger('stackdriver-2')
         self.assertEqual(logger.logging_provider, 'stackdriver')
@@ -121,7 +123,7 @@ class TestStackDriverLogger(unittest.TestCase):
     @mock.patch("google.cloud.logging.Client")
     def test_get_stackdriver_logger_and_log_info(self, mocked_cls):
         """"""
-        temlogger.config.set_logging_provider('stackdriver')
+        temlogger.config.set_provider('stackdriver')
 
         logger = temlogger.getLogger('stackdriver-2')
 
@@ -131,4 +133,5 @@ class TestStackDriverLogger(unittest.TestCase):
 
         logger.info('StackDriver log')
 
-        logger._log.assert_called_once_with(logging.INFO, 'StackDriver log', ())
+        logger._log.assert_called_once_with(
+            logging.INFO, 'StackDriver log', ())


### PR DESCRIPTION
### Refactor of usage interface:
```bash
LOGGING_PROVIDER='logstash'
LOGGING_URL='localhost'
LOGGING_PORT='5000'
LOGGING_ENVIRONMENT='staging'
```
#### Is it now.
```bash
TEMLOGGER_PROVIDER='logstash'
TEMLOGGER_URL='localhost'
TEMLOGGER_PORT='5000'
TEMLOGGER_ENVIRONMENT='staging'
```
### And that:
```python
temlogger.config.set_logging_provider('logstash')
temlogger.config.set_logging_url('localhost')
temlogger.config.set_logging_port(5000)
temlogger.config.set_logging_environment('staging')
```
#### Is it now:

```python
temlogger.config.set_provider('logstash')
temlogger.config.set_url('localhost')
temlogger.config.set_port(5000)
temlogger.config.set_environment('staging')
```