### PR TITLE
Ensures StackDriver worker thread is alive when send logs 

### DIFF
--- a/temlogger/helpers.py
+++ b/temlogger/helpers.py
@@ -1,8 +1,6 @@
 import base64
 import tempfile
 
-
-from google.cloud.logging import Client as LoggingClient
 from importlib import import_module
 
 
@@ -43,6 +41,8 @@ def import_string_list(dotted_path_list=[]):
 
 
 def load_google_client(base64_data, scopes=[]):
+    from google.cloud.logging import Client as LoggingClient
+
     if not base64_data:
         return ''
 

--- a/temlogger/providers/stackdriver.py
+++ b/temlogger/providers/stackdriver.py
@@ -20,5 +20,4 @@ class StackDriverLoggingHandler(CloudLoggingHandler):
 
     def emit(self, record):
         self.ensure_transport_worker_is_running()
-        message = super(CloudLoggingHandler, self).format(record)
-        self.transport.send(record, message, resource=self.resource, labels=self.labels)
+        super().emit(record)

--- a/temlogger/providers/stackdriver.py
+++ b/temlogger/providers/stackdriver.py
@@ -1,3 +1,4 @@
+from google.cloud.logging.handlers import CloudLoggingHandler
 from .base import FormatterBase
 
 
@@ -6,3 +7,18 @@ class StackDriverFormatter(FormatterBase):
     def format(self, record):
         message = super().format(record)
         return message
+
+
+class StackDriverLoggingHandler(CloudLoggingHandler):
+
+    def ensure_transport_worker_is_running(self):
+        """
+        Ensures that transport worker is running when any log is done
+        """
+        if not self.transport.worker.is_alive:
+            self.transport.worker.start()
+
+    def emit(self, record):
+        self.ensure_transport_worker_is_running()
+        message = super(CloudLoggingHandler, self).format(record)
+        self.transport.send(record, message, resource=self.resource, labels=self.labels)

--- a/temlogger/temlogger.py
+++ b/temlogger/temlogger.py
@@ -116,6 +116,7 @@ class LoggerManager:
         logger = logging.getLogger(name)
         has_log_provider = hasattr(logger, 'logging_provider')
         if has_log_provider and logger.logging_provider == logging_provider:
+            logger = self._handle_existing_stackdriver_logger(logger)
             return logger
 
         logger.handlers.clear()
@@ -175,12 +176,29 @@ class LoggerManager:
 
         return logger
 
+    def _handle_existing_stackdriver_logger(self, logger):
+        from google.cloud.logging.handlers import CloudLoggingHandler
+
+        if logger.logging_provider != LoggingProvider.STACK_DRIVER:
+            return logger
+
+        if not logger.handlers:
+            return logger
+
+        for handler in logger.handlers:
+            has_transport_attr = hasattr(handler, 'transport')
+            if isinstance(handler, CloudLoggingHandler) and has_transport_attr:
+                if not handler.transport.worker.is_alive:
+                    handler.transport.worker.start()
+        return logger
+
     def get_logger_stackdriver(self, name, event_handlers=[]):
         """
         Docs: https://googleapis.dev/python/logging/latest/handlers.html
         """
         import google.cloud.logging
         from .providers.stackdriver import StackDriverFormatter
+        from .providers.stackdriver import StackDriverLoggingHandler
 
         app_name = config.get_app_name()
         logging_environment = config.get_environment()
@@ -198,6 +216,7 @@ class LoggerManager:
         logger.logging_provider = LoggingProvider.STACK_DRIVER
 
         handler = client.get_default_handler()
+        handler = StackDriverLoggingHandler(client)
 
         # Setup logger explicitly with this handler
         handler.setFormatter(StackDriverFormatter(


### PR DESCRIPTION
Ensures StackDriver worker thread is alive when send any logs(DEBUG, INFO, WARNING, ERROR..)